### PR TITLE
Eliminate effect on scrollback buffer

### DIFF
--- a/ding/ding.py
+++ b/ding/ding.py
@@ -83,10 +83,17 @@ def print_time(seconds):
     os.system('cls' if os.name == 'nt' else 'clear') # initial clear
     while seconds > 0:
         start = time.time()
+
+        # print the time without a newline or carriage return
+        # this leaves the cursor at the end of the time while visible
         print(datetime.timedelta(seconds=seconds), end='')
         sys.stdout.flush()
         seconds -= 1
         time.sleep(1 - time.time() + start)
+
+        # emit a carriage return
+        # this moves the cursor back to the beginning of the line
+        # so the next time overwrites the current time
         print(end='\r')
 
 

--- a/ding/ding.py
+++ b/ding/ding.py
@@ -82,10 +82,15 @@ def print_time(seconds):
     """Print countdown for `seconds`"""
     while seconds > 0:
         start = time.time()
-        os.system('cls' if os.name == 'nt' else 'clear') # accommodate Windows
-        print(datetime.timedelta(seconds=seconds))
+        if os.name == 'nt':
+            os.system('cls')
+            print(datetime.timedelta(seconds=seconds))
+        else:
+            print(datetime.timedelta(seconds=seconds), end='')
+        sys.stdout.flush()
         seconds -= 1
         time.sleep(1 - time.time() + start)
+        if os.name != 'nt': print(end='\r')
 
 
 def beep(seconds):
@@ -112,6 +117,7 @@ def main(args=sys.argv[1:]):
         seconds = parse_time(check_input(args))
     except InvalidArguments as e:
         sys.exit(EXIT_MSG.format(e))
+    os.system('cls' if os.name == 'nt' else 'clear') # initial clear
     print_time(seconds)
     beep(seconds)
 

--- a/ding/ding.py
+++ b/ding/ding.py
@@ -80,6 +80,7 @@ class TimeParser():
 
 def print_time(seconds):
     """Print countdown for `seconds`"""
+    os.system('cls' if os.name == 'nt' else 'clear') # initial clear
     while seconds > 0:
         start = time.time()
         if os.name == 'nt':
@@ -117,7 +118,6 @@ def main(args=sys.argv[1:]):
         seconds = parse_time(check_input(args))
     except InvalidArguments as e:
         sys.exit(EXIT_MSG.format(e))
-    os.system('cls' if os.name == 'nt' else 'clear') # initial clear
     print_time(seconds)
     beep(seconds)
 

--- a/ding/ding.py
+++ b/ding/ding.py
@@ -83,15 +83,11 @@ def print_time(seconds):
     os.system('cls' if os.name == 'nt' else 'clear') # initial clear
     while seconds > 0:
         start = time.time()
-        if os.name == 'nt':
-            os.system('cls')
-            print(datetime.timedelta(seconds=seconds))
-        else:
-            print(datetime.timedelta(seconds=seconds), end='')
+        print(datetime.timedelta(seconds=seconds), end='')
         sys.stdout.flush()
         seconds -= 1
         time.sleep(1 - time.time() + start)
-        if os.name != 'nt': print(end='\r')
+        print(end='\r')
 
 
 def beep(seconds):


### PR DESCRIPTION
I made a change that perhaps you would like to consider. If it is not what you intend with the tool, feel free to close the PR.

Scrollback buffer after running `ding` before change:

```
andars in ~/projects/ding $ python ding/ding.py in 5s
0:00:05
0:00:04
0:00:03
0:00:02
0:00:01
andars in ~/projects/ding $
```

Scrollback buffer after running `ding` after change:

```
andars in ~/projects/ding $ python ding/ding.py in 5s
andars in ~/projects/ding $
```

Appearance while counting down is unchanged.

Behaviour on windows should be unchanged, but I don't have a windows machine available to test.
